### PR TITLE
Expand TypeScript compiler and runtime listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A curated list of TypeScript compilers, transpilers and runtimes targeting vario
 |-|-|-|
 | [AssemblyScript](https://github.com/AssemblyScript/assemblyscript) | `WASM` | TypeScript-like language for WebAssembly. ([playground](https://www.assemblyscript.org/editor.html)) |
 | [ts2lua](https://github.com/TypeScriptToLua/TypeScriptToLua) | `Lua` | Feature-complete TypeScript to Lua compiler. ([playground](https://typescripttolua.github.io/play/)) |
-| [roblox-ts](https://github.com/roblox-ts/roblox-ts) | `Luau` | TypeScript-to-Luau compiler for Roblox. ([playground](https://roblox-ts.com/playground/)) |
+| [roblox-ts](https://github.com/roblox-ts/roblox-ts) | `Luau` | TypeScript-to-Luau compiler for Roblox. ([playground](https://roblox-ts.com/playground)) |
 | [ts2c](https://github.com/andrei-markeev/ts2c) | `C` | Convert Javascript/TypeScript to C ([online demo](https://andrei-markeev.github.io/ts2c/)) |
 | [TypeScript2Cxx](https://github.com/ASDAlexander77/TypeScript2Cxx) | `C++` | TypeScript to C++ transpiler. |
 | [ts2gd](https://github.com/johnfn/ts2gd) | `GDScript` | Compile TypeScript to GDScript for Godot. |

--- a/README.md
+++ b/README.md
@@ -4,39 +4,55 @@ A curated list of TypeScript compilers, transpilers and runtimes targeting vario
 ## JavaScript Targets
 | Project | Description |
 |-|-|
-| [tsc](https://github.com/microsoft/TypeScript) | Official TypeScript compiler by Microsoft. ([playground](https://www.typescriptlang.org/play)) |
+| [tsc](https://github.com/microsoft/TypeScript) | Official TypeScript compiler by Microsoft. ([playground](https://www.typescriptlang.org/play/)) |
 | [tsgo](https://github.com/microsoft/typescript-go) | Go-based TypeScript compiler by Microsoft targeting 10x performance. |
 | [swc](https://github.com/swc-project/swc) | Rust-based platform for fast TypeScript/JavaScript compilation. ([playground](https://swc.rs/playground)) |
 | [esbuild](https://github.com/evanw/esbuild) | Extremely fast TypeScript/JavaScript bundler written in Go. ([playground](https://esbuild.github.io/try/)) |
+| [vite](https://github.com/vitejs/vite) | Next generation frontend tooling with TypeScript support. ([playground](https://vite.new)) |
+| [rspack](https://github.com/web-infra-dev/rspack) | Rust-based Webpack-compatible bundler with TypeScript support. |
+| [turbopack](https://turborepo.com/pack) | Rust-based incremental bundler by Vercel for JavaScript/TypeScript. |
+| [turborepo](https://github.com/vercel/turborepo) | High-performance monorepo build system optimized for JS/TS, written in Rust. |
+| [biome](https://github.com/biomejs/biome) | Successor to Rome providing a unified TypeScript toolchain. ([playground](https://biomejs.dev/playground/)) |
+| [rolldown](https://github.com/rolldown/rolldown) | Fast Rust bundler for JavaScript/TypeScript with Rollup-compatible API. |
+| [farm](https://github.com/farm-fe/farm) | Extremely fast Vite-compatible web build tool written in Rust. |
+| [oxc](https://github.com/oxc-project/oxc) | Rust-based JavaScript/TypeScript toolchain including parser, linter, and compiler. ([playground](https://playground.oxc.rs/)) |
+| [webpack](https://github.com/webpack/webpack) | JavaScript bundler with TypeScript integration. |
+| [rollup](https://github.com/rollup/rollup) | JavaScript module bundler with TypeScript support. ([repl](https://rollupjs.org/repl/)) |
+| [parcel](https://github.com/parcel-bundler/parcel) | Zero configuration web app bundler with TypeScript support. |
+| [tsup](https://github.com/egoist/tsup) | TypeScript bundler powered by esbuild. |
 | [babel](https://github.com/babel/babel) | The compiler for next generation JavaScript with TypeScript support. ([playground](https://babeljs.io/repl)) |
 | [sucrase](https://github.com/alangpierce/sucrase) | Super-fast alternative to Babel focusing on modern JS runtimes. ([playground](https://sucrase.io/)) |
-| [oxc](https://github.com/oxc-project/oxc) | Rust-based JavaScript/TypeScript toolchain including parser, linter, and compiler. ([playground](https://playground.oxc.rs/)) |
-| [ezno](https://github.com/kaleidawave/ezno) | JavaScript compiler and TypeScript checker in Rust focusing on static analysis. |
+| [ezno](https://github.com/kaleidawave/ezno) | JavaScript compiler and TypeScript checker in Rust focusing on static analysis. ([playground](https://kaleidawave.github.io/ezno/playground/)) |
 | [stc](https://github.com/dudykr/stc) | Rust-based static type checker for TypeScript focusing on performance. |
-| [tsup](https://github.com/egoist/tsup) | TypeScript bundler powered by esbuild. |
-| [rollup](https://github.com/rollup/rollup) | JavaScript module bundler with TypeScript support. |
 
 ## Runtimes
 | Project | Description |
 |-|-|
-| [deno](https://github.com/denoland/deno) | Secure TypeScript runtime & toolkit written in Rust. |
+| [deno](https://github.com/denoland/deno) | Secure TypeScript runtime & toolkit written in Rust. ([playground](https://deno.com/play)) |
 | [bun](https://github.com/oven-sh/bun) | Fast JavaScript and TypeScript runtime & toolkit written in Zig. |
-| [elsa](https://github.com/elsaland/elsa) | Minimal runtime for JavaScript and TypeScript written in Go. |
 | [node.js 23.6.0+](https://github.com/nodejs/node/pull/56450) | Partial support in 23.6.0 |
+| [tsx](https://github.com/privatenumber/tsx) | Run TypeScript with an esbuild-powered ESM loader. |
+| [ts-node](https://github.com/TypeStrong/ts-node) | TypeScript execution and REPL for Node.js. |
+| [jiti](https://github.com/unjs/jiti) | Runtime TypeScript and ESM support for Node.js. |
+| [elsa](https://github.com/elsaland/elsa) | Minimal runtime for JavaScript and TypeScript written in Go. |
 
 ## Other Language Targets
 | Project | Target | Description |
 |-|-|-|
 | [AssemblyScript](https://github.com/AssemblyScript/assemblyscript) | `WASM` | TypeScript-like language for WebAssembly. ([playground](https://www.assemblyscript.org/editor.html)) |
 | [ts2lua](https://github.com/TypeScriptToLua/TypeScriptToLua) | `Lua` | Feature-complete TypeScript to Lua compiler. ([playground](https://typescripttolua.github.io/play/)) |
-| [roblox-ts](https://github.com/roblox-ts/roblox-ts) | `Luau` | TypeScript-to-Luau compiler for Roblox. ([playground](https://roblox-ts.com/playground)) |
+| [roblox-ts](https://github.com/roblox-ts/roblox-ts) | `Luau` | TypeScript-to-Luau compiler for Roblox. ([playground](https://roblox-ts.com/playground/)) |
 | [ts2c](https://github.com/andrei-markeev/ts2c) | `C` | Convert Javascript/TypeScript to C ([online demo](https://andrei-markeev.github.io/ts2c/)) |
 | [TypeScript2Cxx](https://github.com/ASDAlexander77/TypeScript2Cxx) | `C++` | TypeScript to C++ transpiler. |
 | [ts2gd](https://github.com/johnfn/ts2gd) | `GDScript` | Compile TypeScript to GDScript for Godot. |
 | [typesl](https://github.com/SieR-VR/typesl) | `GLSL` | Typescript to GLSL transpiler. |
 | [hydro-sdk](https://github.com/hydro-sdk/hydro-sdk) | `Flutter` | No native bridge, no V8. Just Dart. |
 | [ts2nim](https://github.com/bung87/ts2nim) | `Nim` | Typescript to Nim transpiler. |
-| [ts2dart](https://github.com/angular/ts2dart) | `Dart` | TypeScript to Dart transpiler. |
+| [ts2dart](https://github.com/dart-archive/ts2dart) | `Dart` | TypeScript to Dart transpiler. |
+| [speedy.js](https://github.com/MichaReiser/speedy.js) | `WASM` | Compile TypeScript to WebAssembly for accelerated execution. |
+| [ts2rust](https://github.com/vedantroy/ts2rust) | `Rust` | Typescript to Rust transpiler. |
+| [ts2php](https://github.com/searchfe/ts2php) | `PHP` | Typescript to PHP Transpiler. |
+| [ts2py](https://github.com/chayleaf/ts2py) | `Python` | TypeScript to Python converter. |
 
 ## Experimental/Research Projects
 | Project | Type | Description |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ A curated list of TypeScript compilers, transpilers and runtimes targeting vario
 | [vite](https://github.com/vitejs/vite) | Next generation frontend tooling with TypeScript support. ([playground](https://vite.new)) |
 | [rspack](https://github.com/web-infra-dev/rspack) | Rust-based Webpack-compatible bundler with TypeScript support. |
 | [turbopack](https://github.com/vercel/turbopack) | Rust-based incremental bundler by Vercel for JavaScript/TypeScript. |
-| [turborepo](https://github.com/vercel/turborepo) | High-performance monorepo build system optimized for JS/TS, written in Rust. |
 | [biome](https://github.com/biomejs/biome) | Successor to Rome providing a unified TypeScript toolchain. ([playground](https://biomejs.dev/playground/)) |
 | [rolldown](https://github.com/rolldown/rolldown) | Fast Rust bundler for JavaScript/TypeScript with Rollup-compatible API. |
 | [farm](https://github.com/farm-fe/farm) | Extremely fast Vite-compatible web build tool written in Rust. |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ A curated list of TypeScript compilers, transpilers and runtimes targeting vario
 | [esbuild](https://github.com/evanw/esbuild) | Extremely fast TypeScript/JavaScript bundler written in Go. ([playground](https://esbuild.github.io/try/)) |
 | [vite](https://github.com/vitejs/vite) | Next generation frontend tooling with TypeScript support. ([playground](https://vite.new)) |
 | [rspack](https://github.com/web-infra-dev/rspack) | Rust-based Webpack-compatible bundler with TypeScript support. |
-| [turbopack](https://github.com/vercel/turbopack) | Rust-based incremental bundler by Vercel for JavaScript/TypeScript. |
 | [biome](https://github.com/biomejs/biome) | Successor to Rome providing a unified TypeScript toolchain. ([playground](https://biomejs.dev/playground/)) |
 | [rolldown](https://github.com/rolldown/rolldown) | Fast Rust bundler for JavaScript/TypeScript with Rollup-compatible API. |
 | [farm](https://github.com/farm-fe/farm) | Extremely fast Vite-compatible web build tool written in Rust. |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A curated list of TypeScript compilers, transpilers and runtimes targeting vario
 ## JavaScript Targets
 | Project | Description |
 |-|-|
-| [tsc](https://github.com/microsoft/TypeScript) | Official TypeScript compiler by Microsoft. ([playground](https://www.typescriptlang.org/play/)) |
+| [tsc](https://github.com/microsoft/TypeScript) | Official TypeScript compiler by Microsoft. ([playground](https://www.typescriptlang.org/play)) |
 | [tsgo](https://github.com/microsoft/typescript-go) | Go-based TypeScript compiler by Microsoft targeting 10x performance. |
 | [swc](https://github.com/swc-project/swc) | Rust-based platform for fast TypeScript/JavaScript compilation. ([playground](https://swc.rs/playground)) |
 | [esbuild](https://github.com/evanw/esbuild) | Extremely fast TypeScript/JavaScript bundler written in Go. ([playground](https://esbuild.github.io/try/)) |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A curated list of TypeScript compilers, transpilers and runtimes targeting vario
 | [esbuild](https://github.com/evanw/esbuild) | Extremely fast TypeScript/JavaScript bundler written in Go. ([playground](https://esbuild.github.io/try/)) |
 | [vite](https://github.com/vitejs/vite) | Next generation frontend tooling with TypeScript support. ([playground](https://vite.new)) |
 | [rspack](https://github.com/web-infra-dev/rspack) | Rust-based Webpack-compatible bundler with TypeScript support. |
-| [turbopack](https://turborepo.com/pack) | Rust-based incremental bundler by Vercel for JavaScript/TypeScript. |
+| [turbopack](https://github.com/vercel/turbopack) | Rust-based incremental bundler by Vercel for JavaScript/TypeScript. |
 | [turborepo](https://github.com/vercel/turborepo) | High-performance monorepo build system optimized for JS/TS, written in Rust. |
 | [biome](https://github.com/biomejs/biome) | Successor to Rome providing a unified TypeScript toolchain. ([playground](https://biomejs.dev/playground/)) |
 | [rolldown](https://github.com/rolldown/rolldown) | Fast Rust bundler for JavaScript/TypeScript with Rollup-compatible API. |


### PR DESCRIPTION
## Summary
- reorder JS targets to spotlight active tooling and push stale entries to the end
- prioritize modern runtime loaders before older options
- group cross-language transpilers by project vitality
- fix outdated URLs and add playground links for major tools

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b06366a6048320bc781735580e07f2